### PR TITLE
Remove deprecated linting rules from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,6 @@ select = [
   "PLE",  # Pylint error https://github.com/charliermarsh/ruff#error-ple
 ]
 ignore = [
-    "ANN101", # Missing type annotation for `self` in method
-    "ANN102", # Missing type annotation for `cls` in classmethod
     "ANN204", # Missing return type annotation for special (dunder) method
     "FBT",    # Using boolean function arguments
     "TD",     # TODOs


### PR DESCRIPTION
tiny change, prevents 2 warnings to be printed during the linting check