### PR TITLE
Test RDI differentiability

### DIFF
--- a/tests/physical_models/crop/test_root_dynamics.py
+++ b/tests/physical_models/crop/test_root_dynamics.py
@@ -234,7 +234,7 @@ class TestDiffRootDynamicsRDI:
 
     def test_gradients_rdi_rd_root_dynamics_numerical(self):
         rdi = torch.nn.Parameter(torch.tensor(0.2, dtype=torch.float64))
-        output_name = "RD"  
+        output_name = "RD"
         numerical_grad = calculate_numerical_grad(
             get_test_diff_root_model, "RDI", rdi.data, output_name
         )


### PR DESCRIPTION
This PR is related to issue #47.

The focus is on the root parameter `RDI`, which should be already differentiable since we use pytorch tensor. 
I have added the corresponding tests to confirm it. 