### PR TITLE
Make `Stem dynamics` differentiable/vectorized

### DIFF
--- a/src/diffwofost/physical_models/crop/stem_dynamics.py
+++ b/src/diffwofost/physical_models/crop/stem_dynamics.py
@@ -142,24 +142,20 @@ class WOFOST_Stem_Dynamics(SimulationObject):
             shape (tuple | torch.Size | None): Target shape for the state and rate variables.
         """
         self.kiosk = kiosk
-        self.params = self.Parameters(parvalues)
-        self.rates = self.RateVariables(kiosk, publish=["DRST", "GRST"])
-
-        # INITIAL STATES
-        params = self.params
-        shape = params.shape
+        self.params = self.Parameters(parvalues, shape=shape)
+        self.rates = self.RateVariables(kiosk, publish=["DRST", "GRST"], shape=shape)
 
         # Set initial stem biomass
-        TDWI = params.TDWI
+        TDWI = self.params.TDWI
         FS = self.kiosk["FS"]
         FR = self.kiosk["FR"]
         WST = (TDWI * (1 - FR)) * FS
-        DWST = torch.zeros(shape, dtype=self.dtype, device=self.device)
+        DWST = torch.zeros(self.params.shape, dtype=self.dtype, device=self.device)
         TWST = WST + DWST
 
         # Initial Stem Area Index
         DVS = self.kiosk["DVS"]
-        SSATB = params.SSATB
+        SSATB = self.params.SSATB
         SAI = WST * SSATB(DVS)
 
         self.states = self.StateVariables(

--- a/tests/physical_models/crop/test_stem_dynamics.py
+++ b/tests/physical_models/crop/test_stem_dynamics.py
@@ -14,7 +14,7 @@ from .. import phy_data_folder
 
 stem_dynamics_config = Configuration(
     CROP=WOFOST_Stem_Dynamics,
-    OUTPUT_VARS=["SAI", "TWST"],
+    OUTPUT_VARS=["SAI", "TWST", "WST"],
 )
 
 # [!] Notice that the stem module does not have dedicated test data.
@@ -129,7 +129,7 @@ class DiffStemDynamics(torch.nn.Module):
         engine.run_till_terminate()
         results = engine.get_output()
 
-        return {var: torch.stack([item[var] for item in results]) for var in ["SAI", "TWST"]}
+        return {var: torch.stack([item[var] for item in results]) for var in ["SAI", "TWST", "WST"]}
 
 
 class TestStemDynamics:
@@ -468,7 +468,7 @@ class TestDiffStemDynamicsGradients:
 
     # Define parameters and outputs
     param_names = ["TDWI", "RDRSTB", "SSATB"]
-    output_names = ["SAI", "TWST"]
+    output_names = ["SAI", "TWST", "WST"]
 
     # Define parameter configurations (value, dtype)
     param_configs = {
@@ -501,8 +501,8 @@ class TestDiffStemDynamicsGradients:
     # Define which parameter-output pairs should have gradients
     # Format: {param_name: [list of outputs that should have gradients]}
     gradient_mapping = {
-        "TDWI": ["SAI", "TWST"],
-        "RDRSTB": ["TWST", "SAI"],
+        "TDWI": ["SAI", "TWST", "WST"],
+        "RDRSTB": ["TWST", "SAI", "WST"],
         "SSATB": ["SAI"],
     }
 


### PR DESCRIPTION
Closes #46.

---
Notice that specific test data for the `Stem dynamics` module do **not exist** in `wofost72`, so `test_stem_dynamics.py` implemented in this PR mainly checks the consistency of this new implementation (there are only a few `assert_is_close` statements) .
However, the integration test `test_wofost_pp_with_stem_dynamics` confirms that this new module numerically reproduces the correct results when used in combination with all the other wofost72's modules. 