### PR TITLE
Fix sonar coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,10 +28,8 @@ jobs:
           python -m pip install -e .[dev]
       - name: Run unit tests and store coverage
         run: |
-          # [!] Note that sonarcloud runs the full test suite
-          coverage run -m pytest -n auto
-          coverage report -m
-          coverage xml -o coverage.xml
+          # [!] Note that sonarcloud runs the fast test suite
+          pytest --fast -n auto --cov=your_package --cov-report=xml:coverage.xml --cov-report=term-missing
       - name: Make coverage paths relative
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarQube Scan

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run unit tests and store coverage
         run: |
           # [!] Note that sonarcloud runs the fast test suite
-          pytest --fast -n auto --cov=your_package --cov-report=xml:coverage.xml --cov-report=term-missing
+          pytest --fast -n auto --cov=src --cov-report=xml:coverage.xml --cov-report=term-missing
       - name: Make coverage paths relative
         run: sed -i "s+$PWD/++g" coverage.xml
       - name: SonarQube Scan

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,3 @@ sonar.links.scm=git@github.com:WUR-AI/diffwofost
 sonar.links.issue=https://github.com/WUR-AI/diffwofost/issues
 sonar.links.ci=https://github.com/WUR-AI/diffwofost/actions
 sonar.python.coverage.reportPaths=coverage.xml
-sonar.coverage.exclusions=src/diffwofost/physical_models/crop/evapotranspiration.py,src/diffwofost/physical_models/utils.py


### PR DESCRIPTION
closes #101 

As @SCiarella explained [here](https://github.com/WUR-AI/diffWOFOST/pull/106#issuecomment-4169447121), `coverage run `only tracks coverage for the main process, not the worker subprocesses. Since we have `pytest-cov` as dependency already, I replaced `coverage run` with the `pytest-cov`, which handles parallel coverage correctly. Also, I use `--fast` option for coverage. 
~But I'm not sure how to test this, since this PR doesnot have new codes.~ --> I checked the [results of the action](https://github.com/WUR-AI/diffWOFOST/actions/runs/23938978703/job/69820982080?pr=109), it seems that coverage is now 93% :smile: 